### PR TITLE
fix(RelativeRangeDatePicker): preset popup padding

### DIFF
--- a/src/components/RelativeRangeDatePicker/components/PickerDialog/PickerDialog.scss
+++ b/src/components/RelativeRangeDatePicker/components/PickerDialog/PickerDialog.scss
@@ -6,6 +6,8 @@ $block: '.#{variables.$ns}relative-range-date-picker-dialog';
     &__content {
         --_--popup-content-padding: var(--g-spacing-2);
 
+        --_--g-date-picker-presets-padding: var(--_--popup-content-padding);
+
         padding: var(--_--popup-content-padding);
 
         &_mobile {
@@ -44,5 +46,9 @@ $block: '.#{variables.$ns}relative-range-date-picker-dialog';
         margin-inline: calc(-1 * var(--_--popup-content-padding));
 
         border-block-start: 1px solid var(--g-color-line-generic);
+    }
+
+    &__presets {
+        margin-inline: calc(-1 * var(--_--popup-content-padding));
     }
 }

--- a/src/components/RelativeRangeDatePicker/components/PickerDialog/PickerDialog.tsx
+++ b/src/components/RelativeRangeDatePicker/components/PickerDialog/PickerDialog.tsx
@@ -139,6 +139,7 @@ function DialogContent(
                     }}
                     minValue={props.minValue}
                     docs={props.docs}
+                    className={b('presets')}
                 />
             ) : null}
             {props.withZonesList ? (

--- a/src/components/RelativeRangeDatePicker/components/Presets/Presets.scss
+++ b/src/components/RelativeRangeDatePicker/components/Presets/Presets.scss
@@ -4,12 +4,16 @@
 $block: '.#{variables.$ns}relative-range-date-picker-presets';
 
 #{$block} {
+    --g-list-item-padding: 0 var(--_--g-date-picker-presets-padding, 0);
+
     &__tabs {
         --g-tabs-border-width: 0;
 
         display: flex;
         align-items: center;
         gap: var(--g-spacing-2);
+
+        padding-inline: var(--_--g-date-picker-presets-padding, 0);
 
         box-shadow: inset 0 -1px var(--g-color-line-generic);
     }


### PR DESCRIPTION
corrected padding of popup with list..
before 
<img width="384" alt="image" src="https://github.com/gravity-ui/date-components/assets/42944548/80b4308b-8da9-42c8-9f18-fb4ac2cad9b9">
after
<img width="369" alt="image" src="https://github.com/gravity-ui/date-components/assets/42944548/5f0a9079-9595-413b-8e0c-e7b459587199">
