### PR TITLE
fix(DateField): should show correct input placholder for 24-hour clock format

### DIFF
--- a/src/components/DateField/i18n/en.json
+++ b/src/components/DateField/i18n/en.json
@@ -4,6 +4,7 @@
   "weekday_placeholder": "E",
   "day_placeholder": "D",
   "hour_placeholder": "h",
+  "hour24_placeholder": "H",
   "minute_placeholder": "m",
   "second_placeholder": "s",
   "dayPeriod_placeholder": "aa"

--- a/src/components/DateField/i18n/ru.json
+++ b/src/components/DateField/i18n/ru.json
@@ -4,6 +4,7 @@
   "weekday_placeholder": "ДН",
   "day_placeholder": "Д",
   "hour_placeholder": "ч",
+  "hour24_placeholder": "Ч",
   "minute_placeholder": "м",
   "second_placeholder": "с",
   "dayPeriod_placeholder": "(д|п)п"

--- a/src/components/DateField/utils.ts
+++ b/src/components/DateField/utils.ts
@@ -362,7 +362,11 @@ function getSectionPlaceholder(
         }
 
         case 'hour': {
-            return i18n('hour_placeholder').repeat(2);
+            if (isHour12(currentTokenValue)) {
+                return i18n('hour_placeholder').repeat(2);
+            }
+
+            return i18n('hour24_placeholder').repeat(2);
         }
 
         case 'minute': {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.
