### PR TITLE
fix: typo in i18n validation for later and earlier

### DIFF
--- a/src/components/utils/validation/i18n/ru.json
+++ b/src/components/utils/validation/i18n/ru.json
@@ -1,6 +1,6 @@
 {
-  "Value must be {minValue} or later.": "{{value}} должно ровняться {{minValue}} или быть позже.",
-  "Value must be {maxValue} or earlier.": "{{value}} должно ровняться {{maxValue}} или быть раньше.",
+  "Value must be {minValue} or later.": "{{value}} должно равняться {{minValue}} или быть позже.",
+  "Value must be {maxValue} or earlier.": "{{value}} должно равняться {{maxValue}} или быть раньше.",
   "Selected date unavailable.": "Выбранная дата недоступна.",
   "Value is required.": "{{value}} обязательно.",
   "\"From\"": "«От»",


### PR DESCRIPTION
https://orfo.ruslang.ru/rules/rule/2

По правилу должно быть `равн`

В словах с корнем равн/ровн без ударения 

1) пишется **равн**, если выделяется компонент значения: 
  а) ‘равный: одинаковый’ (равнять доски по длине, уравнять в правах, равнобедренный), 
  **б) ‘равный: сравнение’** (сравнить, несравнимый); _<==== наш случай_

